### PR TITLE
Changing how user membership to teams work

### DIFF
--- a/whwn/migrations/0003_add_membership_model.py
+++ b/whwn/migrations/0003_add_membership_model.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Membership'
+        db.create_table(u'whwn_membership', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created_at', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, auto_now_add=True, blank=True)),
+            ('updated_at', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, auto_now=True, blank=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='memberships', to=orm['whwn.User'])),
+            ('team', self.gf('django.db.models.fields.related.ForeignKey')(related_name='memberships', to=orm['whwn.Team'])),
+            ('is_admin', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('read_only', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'whwn', ['Membership'])
+
+        # Adding unique constraint on 'Membership', fields ['user', 'team']
+        db.create_unique(u'whwn_membership', ['user_id', 'team_id'])
+
+        # Deleting field 'Team.owner'
+        db.delete_column(u'whwn_team', 'owner_id')
+
+        # Deleting field 'User.team'
+        db.delete_column(u'whwn_user', 'team_id')
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Membership', fields ['user', 'team']
+        db.delete_unique(u'whwn_membership', ['user_id', 'team_id'])
+
+        # Deleting model 'Membership'
+        db.delete_table(u'whwn_membership')
+
+        # Adding field 'Team.owner'
+        db.add_column(u'whwn_team', 'owner',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name='owner', null=True, to=orm['whwn.User']),
+                      keep_default=False)
+
+
+        # User chose to not deal with backwards NULL issues for 'User.team'
+        raise RuntimeError("Cannot reverse this migration. 'User.team' and its values cannot be restored.")
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'whwn.category': {
+            'Meta': {'object_name': 'Category'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '32'})
+        },
+        u'whwn.item': {
+            'Meta': {'object_name': 'Item'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'quantity': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1', 'blank': 'True'}),
+            'requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sku': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['whwn.SKU']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
+        },
+        u'whwn.membership': {
+            'Meta': {'unique_together': "(('user', 'team'),)", 'object_name': 'Membership'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'read_only': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['whwn.Team']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['whwn.User']"})
+        },
+        u'whwn.message': {
+            'Meta': {'object_name': 'Message'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['whwn.User']"}),
+            'contents': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'flagged': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['whwn.Team']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
+        },
+        u'whwn.sku': {
+            'Meta': {'object_name': 'SKU'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['whwn.Category']", 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['whwn.Team']"}),
+            'upc': ('django.db.models.fields.CharField', [], {'max_length': '54', 'null': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
+        },
+        u'whwn.team': {
+            'Meta': {'object_name': 'Team'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
+        },
+        u'whwn.user': {
+            'Meta': {'object_name': 'User'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now_add': 'True', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '8', 'decimal_places': '3', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'phone_verified': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['whwn']

--- a/whwn/tests/test_models.py
+++ b/whwn/tests/test_models.py
@@ -4,18 +4,21 @@ from model_mommy import mommy
 
 class UserTestCase(TestCase):
 
-    def test_change_team(self):
+    def test_join_leave_teams(self):
         a = mommy.make('whwn.Team')
         b = mommy.make('whwn.Team')
-        u = mommy.make('whwn.User', team=a)
-        self.assertEqual(u.team, a)
-        u.change_team(b)
-        self.assertEqual(u.team, b)
+        u = mommy.make('whwn.User')
+        u.join_team(a)
+        self.assertIn(a, u.teams)
+        u.join_team(b)
+        self.assertIn(b, u.teams)
+        u.leave_team(a)
+        self.assertNotIn(a, u.teams)
 
     def test_give_item(self):
         t = mommy.make('whwn.Team')
-        u = mommy.make('whwn.User', team=t)
-        v = mommy.make('whwn.User', team=t)
+        u = mommy.make('whwn.User'); v = mommy.make('whwn.User')
+        u.join_team(t); v.join_team(t)
         i = mommy.make('whwn.Item', holder=u, quantity=10)
 
         # Give 3 to team
@@ -37,7 +40,6 @@ class UserTestCase(TestCase):
         self.assertEqual(res1[1].quantity, 7)
 
         # Give the 7 on user u to the team
-        print res[1].quantity
         res2 = u.give_item(t, res1[1], 7)
         self.assertEqual(res2[0], None)
         self.assertEqual(res2[1].holder, t)
@@ -46,8 +48,8 @@ class UserTestCase(TestCase):
 
     def test_send_message_string(self):
         t = mommy.make('whwn.Team')
-        u = mommy.make('whwn.User', team=t)
-        message = u.send_message_str("Test message!")
+        u = mommy.make('whwn.User'); u.join_team(t)
+        message = u.send_message_str(t, "Test message!")
         self.assertIn(message, t.message_set.all())
 
 


### PR DESCRIPTION
Having an inbetween membership model allows us to quickly support
multiple teams as well as have fine grained permissions per user
per team on the membership model. @jnwng @wesvetter @wehaveweneed/core-team 
