### PR TITLE
Added changes to allow delete on zero quantity

### DIFF
--- a/whwn/models.py
+++ b/whwn/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.db import models
+from django.db.models.signals import pre_delete
 from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
 
@@ -57,13 +58,12 @@ class Item(Timestamps, Locatable):
     object_id = models.PositiveIntegerField(null=True)
     holder = generic.GenericForeignKey()
 
-    # TODO: This is causing behavior where all new Items created
-    # (at least by model_mommy) are getting deleted.
-    # def save(self, *args, **kwargs):
-    #     """Replacing save to automatically delete item if quantity is 0"""
-    #     if self.quantity == 0:
-    #         self.delete()
+def Item_pre_delete(sender, instance, **kwargs):
+    if instance.quantity > 0:
+        raise Exception("Item has a positive quantity, and should not be",
+                "deleted.")
 
+pre_delete.connect(Item_pre_delete, sender=Item)
 
 class SKU(Timestamps):
     upc = models.CharField(null=True, blank=True, max_length=54)

--- a/whwn/tests/test_models.py
+++ b/whwn/tests/test_models.py
@@ -2,6 +2,14 @@ from django.test import TestCase
 from model_mommy import mommy
 
 
+TEAM = 'whwn.Team'
+USER = 'whwn.User'
+ITEM = 'whwn.Item'
+CATEGORY = 'whwn.Category'
+SKU = 'whwn.SKU'
+
+
+
 class UserTestCase(TestCase):
 
     def test_change_team(self):
@@ -70,3 +78,18 @@ class SKUTestCase(TestCase):
     def test_upc_on_create(self):
         sku = mommy.make('whwn.SKU')
         self.assertIsNotNone(sku.upc)
+
+class ItemTestCase(TestCase):
+
+    def test_no_delete_on_positive_quantity(self):
+        i1 = mommy.make('whwn.Item', quantity=5)
+        try:
+            i1.delete()
+        except Exception:
+            pass
+
+        i2 = mommy.make('whwn.Item', quantity=0)
+        i2.delete()
+        self.assertTrue(True)
+
+


### PR DESCRIPTION
Deletes can now only be made on zero quantity. I don't know if it makes sense
to allow capabilities to ever force a delete on an item without zero quantity,
it might make sense for the callee to modify the quantity to zero before
deleting as a statement of intent. Thoughts? @jnwng @wesvetter @wehaveweneed/core-team 
