### PR TITLE
Bumping version numbers

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
-Django==1.5.2
-South==0.8.1
+Django==1.6
+South==0.8.2
 psycopg2==2.5.1
 django-tastypie==0.10.0
 mimeparse==0.1.3

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     version=whwn.__version__,
     url='http://github.com/wehaveweneed/wehaveweneed',
     tests_require=['pytest'],
-    install_requires=['Django==1.5.2'],
+    install_requires=['Django==1.6'],
     cmdclass={'test': PyTest},
     description='Inventory Management System',
     long_description=long_description,


### PR DESCRIPTION
Django 1.6 is the latest release. Bumping before it might become a pain to
bump. South 0.8.2 includes some bug fixes as long as an Django 1.6 app cache
fix.
